### PR TITLE
Remove Rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'dotenv'
   gem 'rspec-rails'
-  gem 'rubocop'
   gem 'simplecov'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.1.4)
-    ast (2.3.0)
     builder (3.2.2)
     byebug (9.0.6)
     concurrent-ruby (1.0.2)
@@ -74,11 +73,8 @@ GEM
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
-    parser (2.3.1.2)
-      ast (~> 2.2)
     pg (0.19.0)
     pkg-config (1.1.7)
-    powerpack (0.1.1)
     puma (3.6.2)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -111,7 +107,6 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.1.0)
     rake (11.2.2)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
@@ -133,13 +128,6 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.41.2)
-      parser (>= 2.3.1.1, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
     simplecov (0.12.0)
       docile (~> 1.1.0)
@@ -159,7 +147,6 @@ GEM
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (1.1.0)
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -178,7 +165,6 @@ DEPENDENCIES
   rails_12factor
   rake
   rspec-rails
-  rubocop
   simplecov
   spring
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,6 @@ require_relative 'config/application'
 
 begin
   require 'dotenv/tasks'
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
 rescue LoadError
 end
 


### PR DESCRIPTION
If we use Rubocop we'll do it later through Codeclimate but right now
it's redundant and not necessary.