### PR TITLE
Use Rails 5 API only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
   [@willem-h #8](https://github.com/willem-h/openshelf/pull/8)
 
 ### Changed
+- Use Rails 5 API only mode.
+  [@willem-h #9](https://github.com/willem-h/openshelf/pull/9)
 - Update README.
   [@willem-h #7](https://github.com/willem-h/openshelf/pull/7)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,3 @@
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::API
   protect_from_forgery with: :exception
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,8 +6,6 @@ Bundler.require(*Rails.groups)
 
 module Openshelf
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.api_only = true
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Render debug information on a HTML page
+  config.debug_exception_response_format = :default
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
This app is only going to be an API without serving a web app so
specifying that means that Rails is more likely to work for us.

This change makes use of the new API only mode that can be used in
Rails 5.